### PR TITLE
Set platform to amd64 also for blacksmith ubuntu runner

### DIFF
--- a/.github/workflows/build-multiarch-bot-container.yml
+++ b/.github/workflows/build-multiarch-bot-container.yml
@@ -56,7 +56,7 @@ jobs:
         id: build
         with:
           file: Containerfile
-          platforms: linux/${{ inputs.os == 'ubuntu-latest' || inputs.os == 'blacksmith-4vcpu-ubuntu-2204' && 'amd64' || 'arm64' }}
+          platforms: linux/${{ endsWith(inputs.os, '-arm64') && 'arm64' || 'amd64' }}
           labels: ${{ steps.meta.outputs.labels }}
           provenance: true
           build-args: |

--- a/.github/workflows/build-multiarch-bot-container.yml
+++ b/.github/workflows/build-multiarch-bot-container.yml
@@ -56,7 +56,7 @@ jobs:
         id: build
         with:
           file: Containerfile
-          platforms: linux/${{ inputs.os == 'ubuntu-latest' && 'amd64' || 'arm64' }}
+          platforms: linux/${{ inputs.os == 'ubuntu-latest' || inputs.os == 'blacksmith-4vcpu-ubuntu-2204' && 'amd64' || 'arm64' }}
           labels: ${{ steps.meta.outputs.labels }}
           provenance: true
           build-args: |


### PR DESCRIPTION
The expression in build-multiarch-bot-container.yml did not take into account the blacksmith runner name