### PR TITLE
There are no runners which end in arm64 used in bot repos

### DIFF
--- a/.github/workflows/build-multiarch-bot-container.yml
+++ b/.github/workflows/build-multiarch-bot-container.yml
@@ -49,21 +49,21 @@ jobs:
         with:
           images: ${{ env.GHCR_IMAGE }}
           labels: |
-            org.opencontainers.image.architecture=${{ endsWith(inputs.os, '-arm64') && 'arm64' || 'amd64' }}
+            org.opencontainers.image.architecture=${{ endsWith(inputs.os, '-arm') && 'arm64' || 'amd64' }}
 
       - name: Build and push container for model ${{ inputs.model }}
         uses: docker/build-push-action@v6
         id: build
         with:
           file: Containerfile
-          platforms: linux/${{ endsWith(inputs.os, '-arm64') && 'arm64' || 'amd64' }}
+          platforms: linux/${{ endsWith(inputs.os, '-arm') && 'arm64' || 'amd64' }}
           labels: ${{ steps.meta.outputs.labels }}
           provenance: true
           build-args: |
             BUILDKIT_CONTEXT_KEEP_GIT_DIR=true
             MODEL=${{ inputs.model }}
-          cache-from: type=registry,ref=${{ env.GHCR_IMAGE }}-cache-${{ endsWith(inputs.os, '-arm64') && 'arm64' || 'amd64' }}:${{ inputs.model }}
-          cache-to: type=registry,ref=${{ env.GHCR_IMAGE }}-cache-${{ endsWith(inputs.os, '-arm64') && 'arm64' || 'amd64' }}:${{ inputs.model }},mode=max
+          cache-from: type=registry,ref=${{ env.GHCR_IMAGE }}-cache-${{ endsWith(inputs.os, '-arm') && 'arm64' || 'amd64' }}:${{ inputs.model }}
+          cache-to: type=registry,ref=${{ env.GHCR_IMAGE }}-cache-${{ endsWith(inputs.os, '-arm') && 'arm64' || 'amd64' }}:${{ inputs.model }},mode=max
           outputs: |
             type=image,"name=${{ env.GHCR_IMAGE }}",push-by-digest=true,name-canonical=true,push=true,compression=zstd
 


### PR DESCRIPTION
Currently, all bot repos us only runner images that end with -arm (e.g. ubuntu-24.04-arm, blacksmith-2vcpu-ubuntu-2404-arm)

The expression in the build-multiarch-bot-container.yml therefore evaluates to amd64 for every runner!
This causes (among other things) the cached arm docker images to be outdated and increases build time massively.